### PR TITLE
Cleanup standard flavor 6.1

### DIFF
--- a/flavors/standard-EXASOL-6.1.0/flavor_base/base_test_deps/Dockerfile
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/base_test_deps/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /build_info/packages
 COPY base_test_deps/packages /build_info/packages/base_test_deps
 
 RUN apt-get -y update && \
-    apt-get -y install $(cat /build_info/packages/base_test_deps/apt_get_packages) && \
+    apt-get -y install --no-install-recommends $(cat /build_info/packages/base_test_deps/apt_get_packages) && \
     locale-gen en_US.UTF-8 && \
     update-locale LC_ALL=en_US.UTF-8 && \
     apt-get -y clean && \

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/build_deps/Dockerfile
@@ -13,7 +13,7 @@ ENV BAZEL_PACKAGE_FILE="bazel_$BAZEL_PACKAGE_VERSION-linux-x86_64.deb"
 ENV BAZEL_PACKAGE_URL="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_PACKAGE_VERSION/$BAZEL_PACKAGE_FILE"
 
 RUN apt-get -y update && \
-    apt-get install -y $(cat /build_info/packages/build_deps/apt_get_packages) && \
+    apt-get install --no-install-recommends -y $(cat /build_info/packages/build_deps/apt_get_packages) && \
     curl -L --output "$BAZEL_PACKAGE_FILE" "$BAZEL_PACKAGE_URL" && \
     apt-get install -y "./$BAZEL_PACKAGE_FILE" && \
     rm "$BAZEL_PACKAGE_FILE" && \

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/build_run/Dockerfile
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/build_run/Dockerfile
@@ -14,7 +14,7 @@ COPY /exaudfclient /exaudfclient
 
 WORKDIR /exaudfclient/extension
 RUN ["/bin/bash", "-c", "source /env && bash build.sh --config no-tty --config optimize --config python --config java --config optimize-r --config fast-binary-both"]
-RUN cp -r -L bazel-bin/* /exaudf
+RUN cp -r -L bazel-bin/* /exaudf && rm -r /exaudf/external/bazel_tools/
 RUN mkdir -p /exaudf/python/python3/ /exaudf/javacontainer
 RUN ln -s /exaudf/external/script_languages/python/python3/pyextdataframe.so /exaudf/python/python3/pyextdataframe.so
 RUN ln -s /exaudf/external/script_languages/javacontainer/libexaudf.jar /exaudf/javacontainer/libexaudf.jar

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/Dockerfile
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir -p /build_info/packages/flavor_base_deps
 COPY flavor_base_deps/packages/apt_get_packages /build_info/packages/flavor_base_deps
 
 RUN apt-get -y update && \
-    apt-get -y install $(cat /build_info/packages/flavor_base_deps/apt_get_packages) && \
-	locale-gen en_US.UTF-8 && \
+    apt-get -y install --no-install-recommends $(cat /build_info/packages/flavor_base_deps/apt_get_packages) && \
+	  locale-gen en_US.UTF-8 && \
     update-locale LC_ALL=en_US.UTF-8 && \
     apt-get -y clean && \
     apt-get -y autoremove && \

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -6,6 +6,7 @@ wget
 curl
 maven
 git
+python-setuptools
 python-cffi
 python-cryptography
 python-docutils
@@ -46,6 +47,7 @@ python-boto
 python-pycurl
 python-requests
 python-paramiko
+python3-setuptools
 python3-pycurl
 python3-redis
 python3-smbc

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/language_deps/Dockerfile
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/language_deps/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /build_info/packages
 COPY language_deps/packages /build_info/packages/language_deps
 
 RUN apt-get -y update && \
-    apt-get -y install $(cat /build_info/packages/language_deps/apt_get_packages) && \
+    apt-get -y install --no-install-recommends $(cat /build_info/packages/language_deps/apt_get_packages) && \
     locale-gen en_US.UTF-8 && \
     update-locale LC_ALL=en_US.UTF-8 && \
     apt-get -y clean && \

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/udfclient_deps/Dockerfile
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/udfclient_deps/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /build_info/packages
 COPY udfclient_deps/packages /build_info/packages/udfclient_deps
 
 RUN apt-get -y update && \
-    apt-get -y install $(cat /build_info/packages/udfclient_deps/apt_get_packages) && \
+    apt-get -y install --no-install-recommends $(cat /build_info/packages/udfclient_deps/apt_get_packages) && \
     locale-gen en_US.UTF-8 && \
     update-locale LC_ALL=en_US.UTF-8 && \
     apt-get -y clean && \


### PR DESCRIPTION
- add --no-install-recommends
- remove file /exaudf/external/bazel_tools/
- add python*-setuptools to the required packages

part of #35 