### PR TITLE
 Fix install scripts for empty package lists

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 ce0e779385abedbba0ce54f5f3e866bd561744c8 0	script-languages
+160000 0ae21f287bf1d5b272dcfae7abe4d464dc7de97f 0	script-languages

--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 0ae21f287bf1d5b272dcfae7abe4d464dc7de97f 0	script-languages
+160000 9c6b9ab64c2cde62eb5edc2bda0b4f22046d3353 0	script-languages

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -5,7 +5,7 @@ unzip|6.0-21ubuntu1
 wget|1.19.4-1ubuntu2.2
 curl|7.58.0-2ubuntu3.8
 maven|3.6.0-1~18.04.1
-git|1:2.17.1-1ubuntu0.6
+git|1:2.17.1-1ubuntu0.7
 python-setuptools|39.0.1-2
 python-cffi|1.11.5-1
 python-cryptography|2.1.4-1ubuntu1.3
@@ -33,7 +33,7 @@ python-pypdf2|1.26.0-2
 python-ldb|2:1.2.3-1ubuntu0.1
 python-ldap|3.0.0-1ubuntu0.1
 python-roman|2.0.0-3
-python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.15
+python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.16
 python-sklearn|0.19.1-3
 python-talloc|2.1.10-2ubuntu1
 python-cjson|1.1.0-2

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
-openjdk-11-jdk-headless|11.0.6+10-1ubuntu1~18.04.1
-python2.7-dev|2.7.17-1~18.04
+openjdk-11-jdk-headless|11.0.7+10-2ubuntu2~18.04
+python2.7-dev|2.7.17-1~18.04ubuntu1
 python3-dev|3.6.7-1~18.04
 r-base-core|3.4.4-1ubuntu1
 r-base-dev|3.4.4-1ubuntu1


### PR DESCRIPTION
- Fix install scripts 
  - for empty package lists
  - for lines starting with a comment but without space after #
- Reorganize /ext/scripts directory
- Add tests for list_insalled scripts
- Update apt packages minor versions, because old version are no more available