### PR TITLE
Update and pin dependency versions

### DIFF
--- a/flavors/standard-EXASOL-6.0.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.0.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -1,3 +1,3 @@
 pytz
-azure-storage
+azure-storage==0.36.0
 git+http://github.com/EXASOL/websocket-api.git#egg=exasol-ws-api&subdirectory=python

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -1,5 +1,5 @@
 pytz
-azure-storage
+azure-storage==0.36.0
 git+http://github.com/EXASOL/websocket-api.git#egg=exasol-ws-api&subdirectory=python
 pysftp
 boto3

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-software-properties-common|0.96.24.32.12
+software-properties-common|0.96.24.32.13
 coreutils|8.28-1ubuntu1
 locales|2.27-3ubuntu1
 unzip|6.0-21ubuntu1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -42,7 +42,7 @@ python-numpy|1:1.13.3-2ubuntu1
 python-pandas|0.22.0-4
 python-redis|2.10.6-2ubuntu1
 python-scipy|0.19.1-2ubuntu1
-python-boto|2.44.0-1ubuntu2.18.04.0
+python-boto|2.44.0-1ubuntu2.18.04.1
 python-pycurl|7.43.0.1-0.2
 python-requests|2.18.4-2ubuntu0.1
 python-paramiko|2.0.0-1ubuntu1.2
@@ -67,7 +67,7 @@ python3-jinja2|2.10-1ubuntu0.18.04.1
 python3-cffi|1.11.5-1
 python3-docutils|0.14+dfsg-3
 python3-requests|2.18.4-2ubuntu0.1
-python3-boto|2.44.0-1ubuntu2.18.04.0
+python3-boto|2.44.0-1ubuntu2.18.04.1
 python3-ujson|1.35-2
 python3-paramiko|2.0.0-1ubuntu1.2
 r-base|3.4.4-1ubuntu1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/udfclient_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/udfclient_deps/packages/apt_get_packages
@@ -1,7 +1,7 @@
-software-properties-common|0.96.24.32.12
+software-properties-common|0.96.24.32.13
 coreutils|8.28-1ubuntu1
 locales|2.27-3ubuntu1
 libnss-db|2.2.3pre1-6build2
 libzmq3-dev|4.2.5-1ubuntu0.2
 libprotobuf-dev|3.0.0-9.1ubuntu1
-libssl-dev|1.1.1-1ubuntu2.1~18.04.5
+libssl-dev|1.1.1-1ubuntu2.1~18.04.6


### PR DESCRIPTION
Update:
- software-properties-common
- libssl-dev
- python-boto
- python3-boto

Pin:
- azure-storage to 0.36.0, because 0.37.0 changes the package structure and this needs more investigation, before an update is possible. https://pypi.org/project/azure-storage/0.37.0/