### PR TITLE
Fix error when emitting only one Timestamp column in a dataframe

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 1e0cac875a71d8da757ea14218a524454b1af3b6 0	script-languages
+160000 8eaf9b54f571b564c67be3f968146541ecbcdcec 0	script-languages

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
-openjdk-11-jdk-headless|11.0.7+10-2ubuntu2~18.04
-python2.7-dev|2.7.17-1~18.04ubuntu1
+openjdk-11-jdk-headless|11.0.8+10-0ubuntu1~18.04.1
+python2.7-dev|2.7.17-1~18.04ubuntu1.1
 python3-dev|3.6.7-1~18.04
 r-base-core|3.4.4-1ubuntu1
 r-base-dev|3.4.4-1ubuntu1


### PR DESCRIPTION
Solves #67 

Additional changes:
- Refactoring of emit python_ext_dataframe.cc 
- Additional error codes for python_ext_dataframe.cc
- Explicit error message for dataframes with datetime64 columns which are not datetime64[ns]
- Additional tests for single column dataframe emits
- Exclude tests/test directory from duplicate error code search
- Update some Ubuntu packages because the old versions are not available anymore