### PR TITLE
Add GitHub action trigger for nightly rebuilds

### DIFF
--- a/.github/workflows/nigthly.yaml
+++ b/.github/workflows/nigthly.yaml
@@ -1,0 +1,41 @@
+name: Nightly
+
+on:
+  push:
+    branches-ignore:
+      - "master"
+  # schedule:
+  #   # * is a special character in YAML so you have to quote this string
+  #   - cron:  '0 1 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+        - standard-EXASOL-7.0.0
+        - standard-EXASOL-6.1.0
+        - standard-EXASOL-6.0.0
+        - python3-ds-EXASOL-6.1.0
+        - python3-ds-EXASOL-6.0.0
+        - fancyr-EXASOL-6.1.0
+        - fancyr-EXASOL-6.0.0
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Init submodules
+      run: git submodule update --init --recursive
+
+    - name: Setup Python 3.6 for integration-test-docker-environment
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install pipenv
+      uses: dschep/install-pipenv-action@v1
+
+    - name: Run db test
+      run: "./exaslct run-db-test --flavor-path flavors/${{ matrix.flavor }}"

--- a/.github/workflows/nigthly.yaml
+++ b/.github/workflows/nigthly.yaml
@@ -38,4 +38,4 @@ jobs:
       uses: dschep/install-pipenv-action@v1
 
     - name: Run db test
-      run: "./exaslct run-db-test --flavor-path flavors/${{ matrix.flavor }}"
+      run: "./exaslct run-db-test --flavor-path flavors/${{ matrix.flavor }} --force-rebuild"

--- a/.github/workflows/nigthly.yaml
+++ b/.github/workflows/nigthly.yaml
@@ -11,17 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor:
-        - standard-EXASOL-7.0.0
-        - standard-EXASOL-6.1.0
-        - standard-EXASOL-6.0.0
-        - python3-ds-EXASOL-6.1.0
-        - python3-ds-EXASOL-6.0.0
-        - fancyr-EXASOL-6.1.0
-        - fancyr-EXASOL-6.0.0
 
     steps:
     - uses: actions/checkout@v2
@@ -29,13 +18,24 @@ jobs:
     - name: Init submodules
       run: git submodule update --init --recursive
 
-    - name: Setup Python 3.6 for integration-test-docker-environment
-      uses: actions/setup-python@v2
+    - name: Get Time
+      id: time
+      uses: nanzm/get-time-action@v1.0
       with:
-        python-version: 3.6
+        timeZone: 0
+        format: 'YYYY_MM_DD_HH_mm_ss'
 
-    - name: Install pipenv
-      uses: dschep/install-pipenv-action@v1
+    - name: Create new branch
+      run: "git checkout -b rebuild/nightly_${{ steps.time.outputs.time }}"
 
-    - name: Run db test
-      run: "./exaslct run-db-test --flavor-path flavors/${{ matrix.flavor }} --force-rebuild"
+    - name: Create new empty commit 
+      run: |
+        git config --local user.email "opensource@exasol.com"
+        git config --local user.name "GitHub Action"
+        git commit --allow-empty -m 'nightly_${{ steps.time.outputs.time }}'
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/nigthly.yaml
+++ b/.github/workflows/nigthly.yaml
@@ -25,11 +25,9 @@ jobs:
         timeZone: 0
         format: 'YYYY_MM_DD_HH_mm_ss'
 
-    - name: Create new branch
-      run: "git checkout -b rebuild/nightly_${{ steps.time.outputs.time }}"
-
     - name: Create new empty commit 
       run: |
+        git checkout -b rebuild/nightly_${{ steps.time.outputs.time }}
         git config --local user.email "opensource@exasol.com"
         git config --local user.name "GitHub Action"
         git commit --allow-empty -m 'nightly_${{ steps.time.outputs.time }}'
@@ -38,4 +36,4 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-
+        branch: rebuild/nightly_${{ steps.time.outputs.time }}

--- a/.github/workflows/nigthly.yaml
+++ b/.github/workflows/nigthly.yaml
@@ -1,15 +1,11 @@
-name: Nightly
+name: Trigger Nightly Rebuild of origin/master
 
 on:
-  push:
-    branches-ignore:
-      - "master"
-  # schedule:
-  #   # * is a special character in YAML so you have to quote this string
-  #   - cron:  '0 1 * * *'
+  schedule:
+    - cron:  '0 1 * * *'
 
 jobs:
-  test:
+  trigger_nightly_rebuild:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nigthly.yaml
+++ b/.github/workflows/nigthly.yaml
@@ -3,6 +3,9 @@ name: Trigger Nightly Rebuild of origin/master
 on:
   schedule:
     - cron:  '0 1 * * *'
+  push:
+    branches-ignore:
+      - master
 
 jobs:
   trigger_nightly_rebuild:
@@ -16,10 +19,7 @@ jobs:
 
     - name: Get Time
       id: time
-      uses: nanzm/get-time-action@v1.0
-      with:
-        timeZone: 0
-        format: 'YYYY_MM_DD_HH_mm_ss'
+      run: echo "::set-output name=time::$(date -u +'+%Y_%m_%d_%H_%M_%S')"
 
     - name: Create new empty commit 
       run: |

--- a/.github/workflows/nigthly.yaml
+++ b/.github/workflows/nigthly.yaml
@@ -3,9 +3,10 @@ name: Trigger Nightly Rebuild of origin/master
 on:
   schedule:
     - cron:  '0 1 * * *'
-  push:
-    branches-ignore:
-      - master
+# Push trigger is only for test purposes
+#  push:
+#    branches-ignore:
+#      - master
 
 jobs:
   trigger_nightly_rebuild:
@@ -19,7 +20,7 @@ jobs:
 
     - name: Get Time
       id: time
-      run: echo "::set-output name=time::$(date -u +'+%Y_%m_%d_%H_%M_%S')"
+      run: echo "::set-output name=time::$(date -u '+%Y_%m_%d_%H_%M_%S')"
 
     - name: Create new empty commit 
       run: |


### PR DESCRIPTION
- We use a scheduled GitHub Actions to trigger a complete rebuild on Google Cloud Build
- We cannot use GitHub Actions, because the VMs do not provide enough disk space
- We trigger the rebuild by creating a new branch with the prefix `rebuild/nightly_` and a new empty commit it this branch. Afterwards, we are pushing this branch to GitHub and trigger with it the Google Cloud Build.
- The GitHub Action is schedule for 1am every day

Closes #73 