### PR TITLE
Update apt-packages for standard-EXASOL-7.0.0

### DIFF
--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -15,8 +15,8 @@ python-ipaddress|1.0.17-1
 ipython|5.5.0-1
 python-jinja2|2.10-1ubuntu0.18.04.1
 python-martian|0.14-0ubuntu1
-python-pip|9.0.1-2.3~ubuntu1.18.04.2
-python3-pip|9.0.1-2.3~ubuntu1.18.04.2
+python-pip|9.0.1-2.3~ubuntu1.18.04.3
+python3-pip|9.0.1-2.3~ubuntu1.18.04.3
 python-protobuf|3.0.0-9.1ubuntu1
 python-pyasn1|0.4.2-3
 python-pyasn1-modules|0.2.1-0.2
@@ -32,7 +32,7 @@ python-pypdf2|1.26.0-2
 python-ldb|2:1.2.3-1ubuntu0.1
 python-ldap|3.0.0-1ubuntu0.1
 python-roman|2.0.0-3
-python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.19
+python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.20
 python-sklearn|0.19.1-3
 python-talloc|2.1.10-2ubuntu1
 python-cjson|1.1.0-2


### PR DESCRIPTION
Updated apt-packages:

python-pip: 9.0.1-2.3~ubuntu1.18.04.2 -> 9.0.1-2.3~ubuntu1.18.04.3
python-pip: 9.0.1-2.3~ubuntu1.18.04.2 -> 9.0.1-2.3~ubuntu1.18.04.3
python-samba: 2:4.7.6+dfsg~ubuntu-0ubuntu2.19 -> 2:4.7.6+dfsg~ubuntu-0ubuntu2.20

Fixes #108 