### PR TITLE
Update dependencies

### DIFF
--- a/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -3,3 +3,6 @@ azure-storage==0.36.0
 git+http://github.com/EXASOL/websocket-api.git#egg=exasol-ws-api&subdirectory=python
 pysftp
 boto3
+urllib3==1.25.11 #we need urllib3 1.25.11 to get requests running
+requests==2.24.0 #we need a newer requests version, because older use non public modules from urllib3
+

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -15,8 +15,8 @@ python-ipaddress|1.0.17-1
 ipython|5.5.0-1
 python-jinja2|2.10-1ubuntu0.18.04.1
 python-martian|0.14-0ubuntu1
-python-pip|9.0.1-2.3~ubuntu1.18.04.3
-python3-pip|9.0.1-2.3~ubuntu1.18.04.3
+python-pip|9.0.1-2.3~ubuntu1.18.04.4
+python3-pip|9.0.1-2.3~ubuntu1.18.04.4
 python-protobuf|3.0.0-9.1ubuntu1
 python-pyasn1|0.4.2-3
 python-pyasn1-modules|0.2.1-0.2

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
 openjdk-11-jdk-headless|11.0.8+10-0ubuntu1~18.04.1
-python2.7-dev|2.7.17-1~18.04ubuntu1.1
+python2.7-dev|2.7.17-1~18.04ubuntu1.2
 python3-dev|3.6.7-1~18.04
 r-base-core|3.4.4-1ubuntu1
 r-base-dev|3.4.4-1ubuntu1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.8+10-0ubuntu1~18.04.1
+openjdk-11-jdk-headless|11.0.9+11-0ubuntu1~18.04.1
 python2.7-dev|2.7.17-1~18.04ubuntu1.2
 python3-dev|3.6.7-1~18.04
 r-base-core|3.4.4-1ubuntu1


### PR DESCRIPTION
- Update apt-packages for standard-EXASOL-7.0.0 flavor
- Pin python2 package versions to urllib3 1.25.11 and requests 2.24.0 in standard-EXASOL-6.1.0 flavor, because problems when using the apt-packages

Closes #114 
Closes #112 