### PR TITLE
Update openjdk-11-jdk-headless for standard flavor 6.2 and 7.0

### DIFF
--- a/flavors/standard-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.9+11-0ubuntu1~18.04.1
+openjdk-11-jdk-headless|11.0.9.1+1-0ubuntu1~18.04
 python2.7-dev|2.7.17-1~18.04ubuntu1.2
 python3-dev|3.6.7-1~18.04
 r-base-core|3.4.4-1ubuntu1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.9+11-0ubuntu1~18.04.1
+openjdk-11-jdk-headless|11.0.9.1+1-0ubuntu1~18.04
 python2.7-dev|2.7.17-1~18.04ubuntu1.2
 python3-dev|3.6.7-1~18.04
 r-base-core|3.4.4-1ubuntu1


### PR DESCRIPTION
Fixes #133 