### PR TITLE
Update apt dependencies for standard flavors 6.2 and 7.0

### DIFF
--- a/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -36,7 +36,7 @@ python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.21
 python-sklearn|0.19.1-3
 python-talloc|2.1.10-2ubuntu1
 python-cjson|1.1.0-2
-python-lxml|4.2.1-1ubuntu0.2
+python-lxml|4.2.1-1ubuntu0.3
 python-numpy|1:1.13.3-2ubuntu1
 python-pandas|0.22.0-4
 python-redis|2.10.6-2ubuntu1
@@ -56,7 +56,7 @@ python3-leveldb|0~svn68-3build3
 python3-openssl|17.5.0-1ubuntu1
 python3-pyodbc|4.0.17-1
 python3-numpy|1:1.13.3-2ubuntu1
-python3-lxml|4.2.1-1ubuntu0.2
+python3-lxml|4.2.1-1ubuntu0.3
 python3-sklearn|0.19.1-3
 python3-scipy|0.19.1-2ubuntu1
 python3-pandas|0.22.0-4ubuntu1

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -1,6 +1,6 @@
 coreutils|8.28-1ubuntu1
 locales|2.27-3ubuntu1.2
-unzip|6.0-21ubuntu1
+unzip|6.0-21ubuntu1.1
 wget|1.19.4-1ubuntu2.2
 curl|7.58.0-2ubuntu3.12
 maven|3.6.0-1~18.04.1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -36,7 +36,7 @@ python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.21
 python-sklearn|0.19.1-3
 python-talloc|2.1.10-2ubuntu1
 python-cjson|1.1.0-2
-python-lxml|4.2.1-1ubuntu0.2
+python-lxml|4.2.1-1ubuntu0.3
 python-numpy|1:1.13.3-2ubuntu1
 python-pandas|0.22.0-4
 python-redis|2.10.6-2ubuntu1
@@ -56,7 +56,7 @@ python3-leveldb|0~svn68-3build3
 python3-openssl|17.5.0-1ubuntu1
 python3-pyodbc|4.0.17-1
 python3-numpy|1:1.13.3-2ubuntu1
-python3-lxml|4.2.1-1ubuntu0.2
+python3-lxml|4.2.1-1ubuntu0.3
 python3-sklearn|0.19.1-3
 python3-scipy|0.19.1-2ubuntu1
 python3-pandas|0.22.0-4ubuntu1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -1,6 +1,6 @@
 coreutils|8.28-1ubuntu1
 locales|2.27-3ubuntu1.2
-unzip|6.0-21ubuntu1
+unzip|6.0-21ubuntu1.1
 wget|1.19.4-1ubuntu2.2
 curl|7.58.0-2ubuntu3.12
 maven|3.6.0-1~18.04.1


### PR DESCRIPTION
Updated packages:
unzip|6.0-21ubuntu1|6.0-21ubuntu1.1
python-lxml|4.2.1-1ubuntu0.2|4.2.1-1ubuntu0.3
python3-lxml|4.2.1-1ubuntu0.2|4.2.1-1ubuntu0.3

Fixes #155 