### PR TITLE
Fix the exit code of the exaslct start script

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 ec52f2d60526dbec8cdd729bb63be62dc51fffe6 0	script-languages
+160000 859fc9667523469cb973e2777a9bd4ac79db1b93 0	script-languages


### PR DESCRIPTION
The exit code of the python script was hidden by the pipe to tee. I added `set -o pipefail` before running the python script to get the exit code of the failing command in the pipe.

Fixes exasol/script-languages-release#167