### PR TITLE
Update ubuntu package openjdk-11-jdk-headless from to 11.0.10+9-0ubuntu1~18.04

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 b573d48b111965a09a8a5b6f9012b438cc01dabd 0	script-languages
+160000 2588f3f80eb5646c88ef412bd57ed468145d5fcc 0	script-languages

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.9.1+1-0ubuntu1~18.04
+openjdk-11-jdk-headless|11.0.10+9-0ubuntu1~18.04
 python2.7-dev|2.7.17-1~18.04ubuntu1.2
 python3-dev|3.6.7-1~18.04
 python-distutils-extra|2.41ubuntu1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.9.1+1-0ubuntu1~18.04
+openjdk-11-jdk-headless|11.0.10+9-0ubuntu1~18.04
 python2.7-dev|2.7.17-1~18.04ubuntu1.2
 python3-dev|3.6.7-1~18.04
 python-distutils-extra|2.41ubuntu1


### PR DESCRIPTION
```
Package                |Old Version              |New Version
openjdk-11-jdk-headless|11.0.9.1+1-0ubuntu1~18.04|11.0.10+9-0ubuntu1~18.04
```

Fixes #178 