### PR TITLE
Update and pin packages in standard flavors

### DIFF
--- a/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -5,4 +5,4 @@ pysftp
 boto3
 urllib3==1.25.11 #we need urllib3 1.25.11 to get requests running
 requests==2.24.0 #we need a newer requests version, because older use non public modules from urllib3
-rsa==4.7
+rsa==4.5

--- a/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -5,4 +5,4 @@ pysftp
 boto3
 urllib3==1.25.11 #we need urllib3 1.25.11 to get requests running
 requests==2.24.0 #we need a newer requests version, because older use non public modules from urllib3
-
+rsa==4.7

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -3,4 +3,4 @@ azure-storage==0.36.0
 git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
 pysftp==0.2.9
 boto3==1.11.17
-rsa==4.7
+rsa==4.5

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -3,3 +3,4 @@ azure-storage==0.36.0
 git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
 pysftp==0.2.9
 boto3==1.11.17
+rsa==4.7

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/udfclient_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/udfclient_deps/packages/apt_get_packages
@@ -4,4 +4,4 @@ locales|2.27-3ubuntu1.2
 libnss-db|2.2.3pre1-6build2
 libzmq3-dev|4.2.5-1ubuntu0.2
 libprotobuf-dev|3.0.0-9.1ubuntu1
-libssl-dev|1.1.1-1ubuntu2.1~18.04.7
+libssl-dev|1.1.1-1ubuntu2.1~18.04.8

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -3,4 +3,4 @@ azure-storage==0.36.0
 git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
 pysftp==0.2.9
 boto3==1.11.17
-rsa==4.7
+rsa==4.5

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -3,3 +3,4 @@ azure-storage==0.36.0
 git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
 pysftp==0.2.9
 boto3==1.11.17
+rsa==4.7

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/udfclient_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/udfclient_deps/packages/apt_get_packages
@@ -4,4 +4,4 @@ locales|2.27-3ubuntu1.2
 libnss-db|2.2.3pre1-6build2
 libzmq3-dev|4.2.5-1ubuntu0.2
 libprotobuf-dev|3.0.0-9.1ubuntu1
-libssl-dev|1.1.1-1ubuntu2.1~18.04.7
+libssl-dev|1.1.1-1ubuntu2.1~18.04.8


### PR DESCRIPTION
* Pin rsa python package to 4.5 for python2
* Update libssl-dev from 1.1.1-1ubuntu2.1~18.04.7 to 1.1.1-1ubuntu2.1~18.04.8

Fixes #185 
Fixes #182 