### PR TITLE
Update apt package for standard flavors

### DIFF
--- a/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -30,7 +30,7 @@ libldb1|2:1.2.3-1ubuntu0.2
 python-ldb|2:1.2.3-1ubuntu0.2
 python-ldap|3.0.0-1ubuntu0.1
 python-roman|2.0.0-3
-python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.21
+python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.23
 python-sklearn|0.19.1-3
 python-talloc|2.1.10-2ubuntu1
 python-cjson|1.1.0-2

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.10+9-0ubuntu1~18.04
+openjdk-11-jdk-headless|11.0.11+9-0ubuntu2~18.04
 python2.7-dev|2.7.17-1~18.04ubuntu1.6
 python3-dev|3.6.7-1~18.04
 python-distutils-extra|2.41ubuntu1

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -30,7 +30,7 @@ libldb1|2:1.2.3-1ubuntu0.2
 python-ldb|2:1.2.3-1ubuntu0.2
 python-ldap|3.0.0-1ubuntu0.1
 python-roman|2.0.0-3
-python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.21
+python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.23
 python-sklearn|0.19.1-3
 python-talloc|2.1.10-2ubuntu1
 python-cjson|1.1.0-2

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.10+9-0ubuntu1~18.04
+openjdk-11-jdk-headless|11.0.11+9-0ubuntu2~18.04
 python2.7-dev|2.7.17-1~18.04ubuntu1.6
 python3-dev|3.6.7-1~18.04
 python-distutils-extra|2.41ubuntu1

--- a/flavors/standard-EXASOL-7.1.0/flavor_base/flavor_base_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.1.0/flavor_base/flavor_base_deps/packages/apt_get_packages
@@ -30,7 +30,7 @@ libldb1|2:1.2.3-1ubuntu0.2
 python-ldb|2:1.2.3-1ubuntu0.2
 python-ldap|3.0.0-1ubuntu0.1
 python-roman|2.0.0-3
-python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.21
+python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.23
 python-sklearn|0.19.1-3
 python-talloc|2.1.10-2ubuntu1
 python-cjson|1.1.0-2

--- a/flavors/standard-EXASOL-7.1.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-7.1.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-openjdk-11-jdk-headless|11.0.10+9-0ubuntu1~18.04
+openjdk-11-jdk-headless|11.0.11+9-0ubuntu2~18.04
 python2.7-dev|2.7.17-1~18.04ubuntu1.6
 python3-dev|3.6.7-1~18.04
 python-distutils-extra|2.41ubuntu1


### PR DESCRIPTION
Fixes #247 
```
package|old|new
openjdk-11-jdk-headless|11.0.10+9-0ubuntu1~18.04|11.0.11+9-0ubuntu2~18.04
python-samba|2:4.7.6+dfsg~ubuntu-0ubuntu2.21|2:4.7.6+dfsg~ubuntu-0ubuntu2.23
```