### PR TITLE
Remove exaslct implementation and replace it by the starter scripts of exasol/script-languages-container-tool

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 d8d40223e86627a9f10688504329dc30dd04f521 0	script-languages
+160000 a00ec4ee972bb78b6e8ebdf9cc0bd0e7fd428d5c 0	script-languages

--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 28b153bf9c8c01d3679c1dc0dc75e0e5b2ee458c 0	script-languages
+160000 44aac0da9fa36ae4cbff909e32c97f5fe8ae591b 0	script-languages

--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 a00ec4ee972bb78b6e8ebdf9cc0bd0e7fd428d5c 0	script-languages
+160000 7c7c002b18ca8504f517bcbe68a2af0f13fc530e 0	script-languages

--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 7c7c002b18ca8504f517bcbe68a2af0f13fc530e 0	script-languages
+160000 e353527acd4f617a1ae9b233d1fdba1aed5ed08e 0	script-languages

--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 44aac0da9fa36ae4cbff909e32c97f5fe8ae591b 0	script-languages
+160000 d8d40223e86627a9f10688504329dc30dd04f521 0	script-languages

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you are interested in the script client you find more details [here](https://
 ## In a Nutshell
 ### Prerequisites
 
-We are using the [script-languages-container-tool](https://github.com/exasol/script-languages-container-tool) (exaslct) to build the containers. The script-languages-container-tool is already installed into this repository and will fetch all required Docker images when they are not already present. As this you only need to fulfil the [prerequisites for running the script-languages-container-tool](https://github.com/exasol/script-languages-container-tool#for-running).
+We are using the [script-languages-container-tool](https://github.com/exasol/script-languages-container-tool) (exaslct) to build the containers. The script-languages-container-tool is already installed into this repository and will fetch all required Docker images when they are not already present. So, you only need to fulfil the [prerequisites for running the script-languages-container-tool](https://github.com/exasol/script-languages-container-tool#for-running).
 ### Getting Started
 
 If you only want to use pre-built containers, you can find them in the [release section](https://github.com/exasol/script-languages-release/releases) of this repository. However, if you want build custom container you need to clone this repository.
@@ -102,7 +102,7 @@ or upload it directly into your BucketFS (currently http only, https follows soo
 
 Note: The tool `exaslct` tries to reuse as much as possible of the previous build or tries to pull already existing images from Docker Hub.
 
-**Please, refer to the [User Guide of exaslct](https://github.com/exasol/script-languages-container-tool/blob/main/doc/user_guide/user_guide.md) for more detailed information, how to use exalsct.**
+**Please, refer to the [User Guide](https://github.com/exasol/script-languages-container-tool/blob/main/doc/user_guide/user_guide.md) of the script-languages-container-tool project for more detailed information about the usage of exalsct.**
 
 ## Features
 

--- a/exaslct_src
+++ b/exaslct_src
@@ -1,1 +1,0 @@
-script-languages/exaslct_src/

--- a/flavors/r-3.5-data-science-EXASOL-6.2.0/flavor_base/build_steps.py
+++ b/flavors/r-3.5-data-science-EXASOL-6.2.0/flavor_base/build_steps.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from exaslct_src.exaslct.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
+from exasol_script_languages_container_tool.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
 
 
 class AnalyzeUDFClientDeps(DockerFlavorAnalyzeImageTask):

--- a/flavors/r-4.0-minimal-EXASOL-6.2.0/flavor_base/build_steps.py
+++ b/flavors/r-4.0-minimal-EXASOL-6.2.0/flavor_base/build_steps.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from exaslct_src.exaslct.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
+from exasol_script_languages_container_tool.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
 
 
 class AnalyzeUDFClientDeps(DockerFlavorAnalyzeImageTask):

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/build_steps.py
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/build_steps.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from exaslct_src.exaslct.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
+from exasol_script_languages_container_tool.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
 
 
 class AnalyzeUDFClientDeps(DockerFlavorAnalyzeImageTask):

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/build_steps.py
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/build_steps.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from exaslct_src.exaslct.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
+from exasol_script_languages_container_tool.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
 
 
 class AnalyzeUDFClientDeps(DockerFlavorAnalyzeImageTask):

--- a/flavors/standard-EXASOL-7.1.0/flavor_base/build_steps.py
+++ b/flavors/standard-EXASOL-7.1.0/flavor_base/build_steps.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from exaslct_src.exaslct.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
+from exasol_script_languages_container_tool.lib.tasks.build.docker_flavor_image_task import DockerFlavorAnalyzeImageTask
 
 
 class AnalyzeUDFClientDeps(DockerFlavorAnalyzeImageTask):


### PR DESCRIPTION
- Replace exaslct implementation with starter scripts of exasol/script-languages-container-tool
- Note: Using the exalsct from exasol/script-languages-container-tool changes the imports of the build_steps.py of the flavors
- Note: The exaslct starter scripts use a Docker container to run exalsct to reduce the required dependency
- Remove detailed User Guide from Readme and link to User Guide of exasol/script-languages-container-tool
- Improve Readme text

Fixes #243
Fixes #66
Closes  #65