### PR TITLE
Rebuild/documentation/261/check links in markdown files automatically

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 38871fb637cf58a32fd6c317385b4c3281487bf1 0	script-languages
+160000 5148ec455ca4c8322c3adcccbeee8bcd02f05e07 0	script-languages

--- a/.github/workflows/check_markdown_links.yaml
+++ b/.github/workflows/check_markdown_links.yaml
@@ -1,0 +1,10 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/check_markdown_links.yaml
+++ b/.github/workflows/check_markdown_links.yaml
@@ -6,5 +6,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@v2
+      - name: Init submodules
+        run: git submodule update --init --recursive
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
In #256 we discovered several broken links in markup files.
Adding an automatic check helps to avoid these kind of issus in future changes