### PR TITLE
#278: Exasol WebSocket change broke CI builds

### DIFF
--- a/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip3_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip3_packages
@@ -1,6 +1,6 @@
 protobuf==3.17.3
 martian==1.4
-git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
+git+http://github.com/EXASOL/websocket-api.git@758d57d6d076c495b449c9017db3083498c44445#egg=exasol-db-api&subdirectory=python
 pyexasol==0.20.0
 pysftp==0.2.9
 boto3==1.17.96

--- a/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-6.2.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -1,6 +1,6 @@
 pytz==2021.1
 azure-storage==0.36.0 #v0.37.0 is deprecated and breaks the build.
-git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
+git+http://github.com/EXASOL/websocket-api.git@758d57d6d076c495b449c9017db3083498c44445#egg=exasol-db-api&subdirectory=python
 pysftp==0.2.9
 boto3==1.17.96
 rsa==4.5 # higher version of the rsa package don't support python2

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip3_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip3_packages
@@ -1,6 +1,6 @@
 protobuf==3.17.3
 martian==1.4
-git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
+git+http://github.com/EXASOL/websocket-api.git@758d57d6d076c495b449c9017db3083498c44445#egg=exasol-db-api&subdirectory=python
 pyexasol==0.20.0
 pysftp==0.2.9
 boto3==1.17.96

--- a/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip_packages
+++ b/flavors/standard-EXASOL-7.0.0/flavor_base/flavor_base_deps/packages/pip_packages
@@ -1,6 +1,6 @@
 pytz==2021.1
 azure-storage==0.36.0 #v0.37.0 is deprecated and breaks the build.
-git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
+git+http://github.com/EXASOL/websocket-api.git@758d57d6d076c495b449c9017db3083498c44445#egg=exasol-db-api&subdirectory=python
 pysftp==0.2.9
 boto3==1.17.96
 rsa==4.5 # higher version of the rsa package don't support python2

--- a/flavors/standard-EXASOL-7.1.0/flavor_base/flavor_base_deps/packages/python2_pip_packages
+++ b/flavors/standard-EXASOL-7.1.0/flavor_base/flavor_base_deps/packages/python2_pip_packages
@@ -3,7 +3,7 @@ azure-storage-file-datalake|12.4.0
 azure-storage-file-share|12.5.0
 azure-storage-queue|12.1.6
 boto3|1.17.96
-git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python
+git+http://github.com/EXASOL/websocket-api.git@758d57d6d076c495b449c9017db3083498c44445#egg=exasol-db-api&subdirectory=python
 pysftp|0.2.9
 pytz|2021.1
 rsa|4.5 # higher version of the rsa package don't support python2

--- a/flavors/standard-EXASOL-7.1.0/flavor_base/flavor_base_deps/packages/python3_pip_packages
+++ b/flavors/standard-EXASOL-7.1.0/flavor_base/flavor_base_deps/packages/python3_pip_packages
@@ -17,7 +17,7 @@ azure-storage-file-datalake|12.4.0
 azure-storage-file-share|12.5.0
 azure-storage-queue|12.1.6
 boto3|1.17.96
-git+http://github.com/EXASOL/websocket-api.git#egg=exasol-db-api&subdirectory=python|
+git+http://github.com/EXASOL/websocket-api.git@758d57d6d076c495b449c9017db3083498c44445#egg=exasol-db-api&subdirectory=python|
 google-cloud-asset|3.1.0
 google-cloud-bigquery|2.20.0
 google-cloud-bigquery-storage|2.4.0


### PR DESCRIPTION
RCA:
exasol/websocket-api#21
removed Python2.7 support which broke CI builds.

Solution:
We need to pin version of websocket-api to last working version.