### PR TITLE
#281:Update exaslct

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 1c22dd3de9f2a9a798a67ea2fc6e52a47dc3fab8 0	script-languages
+160000 8eb98df0bdcbaf0eec695c53d2b2ec5627d4c613 0	script-languages

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ If you are interested in the script client you find more details [here](https://
 ### Prerequisites
 
 We are using the [script-languages-container-tool](https://github.com/exasol/script-languages-container-tool) (exaslct) to build the containers. The script-languages-container-tool is already installed into this repository and will fetch all required Docker images when they are not already present. So, you only need to fulfil the [prerequisites for running the script-languages-container-tool](https://github.com/exasol/script-languages-container-tool#for-running).
+
+Minimum requirements are:
+* Docker
+* Bash 4.2
+
 ### Getting Started
 
 If you only want to use pre-built containers, you can find them in the [release section](https://github.com/exasol/script-languages-release/releases) of this repository. However, if you want build custom container you need to clone this repository.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you are interested in the script client you find more details [here](https://
 We are using the [script-languages-container-tool](https://github.com/exasol/script-languages-container-tool) (exaslct) to build the containers. The script-languages-container-tool is already installed into this repository and will fetch all required Docker images when they are not already present. So, you only need to fulfil the [prerequisites for running the script-languages-container-tool](https://github.com/exasol/script-languages-container-tool#for-running).
 
 Minimum requirements are:
-* Docker
+* Docker >= 17.05 
 * Bash 4.2
 
 ### Getting Started


### PR DESCRIPTION
Due to https://github.com/exasol/script-languages-container-tool/issues/48
exaslct needs to be updated in order to be compatible with bash 4.2.

Fixes #281.