### PR TITLE
#395: Avoid creating wheel cache in install_via_pip

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 cc58465eb9bb5876d0c7114fbf6a2716937f28a6 0	script-languages
+160000 e33e1e9c82cc0ad14346b60fc6d539b3cc7a8323 0	script-languages

--- a/doc/changes/changes-3.1.0.md
+++ b/doc/changes/changes-3.1.0.md
@@ -14,7 +14,7 @@ This release uses version 0.6.0 of the container tool.
 
 ## Bug Fixes
 
-n/a
+ - #395: Avoid creating wheel cache in install_via_pip
 
 ## Features / Enhancements
 


### PR DESCRIPTION
RCA:

1. pip install with --no-cache-dir works, no cache is beeing created
2. pip installation itself creates already a cache dir with 2 packages: 'http' and 'selfcheck'
3. "pip list" also creates a pip cache

Solution:

1. Remove cache directory after pip installation (No option was found to suppress creation of cache directory during pip installation)
2. Apply no-cache-dir for pip list

### All Submissions:

* [x] Check if your pull request goes to the correct bash branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
