### PR TITLE
#1002: Use ECR fallback repository for Trivy caching

### DIFF
--- a/.github/workflows/update_trivy_cache.yaml
+++ b/.github/workflows/update_trivy_cache.yaml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Fetch trivy databases
         run: |
-          trivy image --download-java-db-only
-          trivy image --download-db-only
+          trivy image --download-java-db-only || (echo "Falling back to ECR repository...." && trivy image --download-java-db-only --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db)
+          trivy image --download-db-only || (echo "Falling back to ECR repository....." && trivy image --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db)
 
       - name: Create tar gz databases
         run: |

--- a/doc/changes/changes_8.4.0.md
+++ b/doc/changes/changes_8.4.0.md
@@ -39,7 +39,7 @@ This release uses version 1.0.0 of the container tool.
 ## Bugs
   - #977: Fixed Trivy update cache workflow
   - #993: Added escape sequence for backslash in new Script Options parser
-
+  - #1002: Use ECR fallback repository for Trivy caching
 ## Doc
 
  - #954: added release checklist


### PR DESCRIPTION
closes #1002 

### All Submissions:

* [x] Check if your pull request goes to the correct bash branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
