### PR TITLE
#958: Fix conda version conflict

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 dfcc16523028c7b980e394eb8bed829de968da0a 0	script-languages
+160000 ba951587d1698df77e2d4a8286d7c4c5c9c61160 0	script-languages

--- a/doc/changes/changes_8.4.0.md
+++ b/doc/changes/changes_8.4.0.md
@@ -42,6 +42,8 @@ This release uses version 1.0.0 of the container tool.
   - #977: Fixed Trivy update cache workflow
   - #993: Added escape sequence for backslash in new Script Options parser
   - #1002: Use ECR fallback repository for Trivy caching
+  - #958: Fix conda version conflict
+
 ## Doc
 
  - #954: added release checklist


### PR DESCRIPTION
closes #958 

### All Submissions:

* [x] Check if your pull request goes to the correct bash branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
