### PR TITLE
#1019: Update Dependencies on top of 8.3.0 

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 1f35fd5226aabf50fb40bec4dec9c4d7d8db9340 0	script-languages
+160000 e46eb9bc18718ce1cbd3cd2cb3714f421d47f141 0	script-languages

--- a/doc/changes/changes_9.0.0.md
+++ b/doc/changes/changes_9.0.0.md
@@ -18,7 +18,8 @@ This release uses version 1.0.0 of the container tool.
 ## Security Issues
 
  - #956: Updated dependencies
- - #1006: Updated Dependencies on top of 8.4.0 
+ - #1006: Updated Dependencies on top of 8.4.0
+ - #1019: Update Dependencies on top of 8.3.0 
 
 ## Refactorings
 

--- a/doc/changes/changes_9.0.0.md
+++ b/doc/changes/changes_9.0.0.md
@@ -18,7 +18,7 @@ This release uses version 1.0.0 of the container tool.
 ## Security Issues
 
  - #956: Updated dependencies
- - #1006: Updated Dependencies on top of 8.4.0
+ - #1006: Updated Dependencies on top of 8.3.0
  - #1019: Update Dependencies on top of 8.3.0 
 
 ## Refactorings

--- a/doc/changes/package_diffs/9.0.0/standard-EXASOL-all/build_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/standard-EXASOL-all/build_deps/apt_get_packages_diff.md
@@ -2,7 +2,7 @@
 
 |    | Package           | Version in 8.3.0             | Version in 9.0.0             | Status   |
 |---:|:------------------|:-----------------------------|:-----------------------------|:---------|
-|  0 | curl              | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.18           | UPDATED  |
+|  0 | curl              | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.19           | UPDATED  |
 |  1 | openjdk-11-jdk    | 11.0.24+8-1ubuntu3~22.04     | 11.0.25+9-1ubuntu1~22.04     | UPDATED  |
 |  2 | build-essential   | 12.9ubuntu3                  | 12.9ubuntu3                  |          |
 |  3 | chrpath           | 0.16-2                       | 0.16-2                       |          |

--- a/doc/changes/package_diffs/9.0.0/standard-EXASOL-all/flavor_base_deps_apt/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/standard-EXASOL-all/flavor_base_deps_apt/apt_get_packages_diff.md
@@ -3,7 +3,7 @@
 |    | Package              | Version in 8.3.0             | Version in 9.0.0             | Status   |
 |---:|:---------------------|:-----------------------------|:-----------------------------|:---------|
 |  0 | apt-transport-https  | 2.4.12                       | 2.4.13                       | UPDATED  |
-|  1 | libcurl4-openssl-dev | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.18           | UPDATED  |
+|  1 | libcurl4-openssl-dev | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.19           | UPDATED  |
 |  2 | build-essential      | 12.9ubuntu3                  | 12.9ubuntu3                  |          |
 |  3 | cmake                | 3.22.1-1ubuntu1.22.04.2      | 3.22.1-1ubuntu1.22.04.2      |          |
 |  4 | git                  | 1:2.34.1-1ubuntu1.11         | 1:2.34.1-1ubuntu1.11         |          |

--- a/doc/changes/package_diffs/9.0.0/standard-EXASOL-all/language_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/standard-EXASOL-all/language_deps/apt_get_packages_diff.md
@@ -3,8 +3,8 @@
 |    | Package                 | Version in 8.3.0         | Version in 9.0.0         | Status   |
 |---:|:------------------------|:-------------------------|:-------------------------|:---------|
 |  0 | ca-certificates         | 20230311ubuntu0.22.04.1  | 20240203~22.04.1         | UPDATED  |
-|  1 | curl                    | 7.81.0-1ubuntu1.17       | 7.81.0-1ubuntu1.18       | UPDATED  |
+|  1 | curl                    | 7.81.0-1ubuntu1.17       | 7.81.0-1ubuntu1.19       | UPDATED  |
 |  2 | openjdk-11-jdk-headless | 11.0.24+8-1ubuntu3~22.04 | 11.0.25+9-1ubuntu1~22.04 | UPDATED  |
-|  3 | python3.10-dev          | 3.10.12-1~22.04.5        | 3.10.12-1~22.04.6        | UPDATED  |
+|  3 | python3.10-dev          | 3.10.12-1~22.04.5        | 3.10.12-1~22.04.7        | UPDATED  |
 |  4 | chrpath                 | 0.16-2                   | 0.16-2                   |          |
 |  5 | python3-distutils       | 3.10.8-1~22.04           | 3.10.8-1~22.04           |          |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-8-python-3.10-cuda-conda__template-Exasol-all-python-3.10-cuda-conda/conda_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-8-python-3.10-cuda-conda__template-Exasol-all-python-3.10-cuda-conda/conda_deps/apt_get_packages_diff.md
@@ -5,5 +5,5 @@
 |  0 | bzip2           |                    | 1.0.8-5build1      | NEW      |
 |  1 | ca-certificates |                    | 20240203~22.04.1   | NEW      |
 |  2 | coreutils       |                    | 8.32-4.1ubuntu1.2  | NEW      |
-|  3 | curl            |                    | 7.81.0-1ubuntu1.18 | NEW      |
+|  3 | curl            |                    | 7.81.0-1ubuntu1.19 | NEW      |
 |  4 | locales         |                    | 2.35-0ubuntu3.8    | NEW      |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-java-17/build_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-java-17/build_deps/apt_get_packages_diff.md
@@ -2,7 +2,7 @@
 
 |    | Package                 | Version in 8.3.0             | Version in 9.0.0             | Status   |
 |---:|:------------------------|:-----------------------------|:-----------------------------|:---------|
-|  0 | curl                    | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.18           | UPDATED  |
+|  0 | curl                    | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.19           | UPDATED  |
 |  1 | openjdk-17-jdk-headless | 17.0.12+7-1ubuntu2~22.04     | 17.0.13+11-2ubuntu1~22.04    | UPDATED  |
 |  2 | build-essential         | 12.9ubuntu3                  | 12.9ubuntu3                  |          |
 |  3 | chrpath                 | 0.16-2                       | 0.16-2                       |          |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-java-17/language_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-java-17/language_deps/apt_get_packages_diff.md
@@ -3,5 +3,5 @@
 |    | Package                 | Version in 8.3.0         | Version in 9.0.0          | Status   |
 |---:|:------------------------|:-------------------------|:--------------------------|:---------|
 |  0 | ca-certificates         | 20230311ubuntu0.22.04.1  | 20240203~22.04.1          | UPDATED  |
-|  1 | curl                    | 7.81.0-1ubuntu1.17       | 7.81.0-1ubuntu1.18        | UPDATED  |
+|  1 | curl                    | 7.81.0-1ubuntu1.17       | 7.81.0-1ubuntu1.19        | UPDATED  |
 |  2 | openjdk-17-jdk-headless | 17.0.12+7-1ubuntu2~22.04 | 17.0.13+11-2ubuntu1~22.04 | UPDATED  |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10-conda/conda_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10-conda/conda_deps/apt_get_packages_diff.md
@@ -3,7 +3,7 @@
 |    | Package         | Version in 8.3.0        | Version in 9.0.0   | Status   |
 |---:|:----------------|:------------------------|:-------------------|:---------|
 |  0 | ca-certificates | 20230311ubuntu0.22.04.1 | 20240203~22.04.1   | UPDATED  |
-|  1 | curl            | 7.81.0-1ubuntu1.17      | 7.81.0-1ubuntu1.18 | UPDATED  |
+|  1 | curl            | 7.81.0-1ubuntu1.17      | 7.81.0-1ubuntu1.19 | UPDATED  |
 |  2 | bzip2           | 1.0.8-5build1           | 1.0.8-5build1      |          |
 |  3 | coreutils       | 8.32-4.1ubuntu1.2       | 8.32-4.1ubuntu1.2  |          |
 |  4 | locales         | 2.35-0ubuntu3.8         | 2.35-0ubuntu3.8    |          |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10/build_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10/build_deps/apt_get_packages_diff.md
@@ -2,7 +2,7 @@
 
 |    | Package           | Version in 8.3.0             | Version in 9.0.0             | Status   |
 |---:|:------------------|:-----------------------------|:-----------------------------|:---------|
-|  0 | curl              | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.18           | UPDATED  |
+|  0 | curl              | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.19           | UPDATED  |
 |  1 | openjdk-11-jdk    | 11.0.24+8-1ubuntu3~22.04     | 11.0.25+9-1ubuntu1~22.04     | UPDATED  |
 |  2 | build-essential   | 12.9ubuntu3                  | 12.9ubuntu3                  |          |
 |  3 | chrpath           | 0.16-2                       | 0.16-2                       |          |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10/flavor_base_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10/flavor_base_deps/apt_get_packages_diff.md
@@ -2,7 +2,7 @@
 
 |    | Package              | Version in 8.3.0     | Version in 9.0.0     | Status   |
 |---:|:---------------------|:---------------------|:---------------------|:---------|
-|  0 | libcurl4-openssl-dev | 7.81.0-1ubuntu1.17   | 7.81.0-1ubuntu1.18   | UPDATED  |
+|  0 | libcurl4-openssl-dev | 7.81.0-1ubuntu1.17   | 7.81.0-1ubuntu1.19   | UPDATED  |
 |  1 | build-essential      | 12.9ubuntu3          | 12.9ubuntu3          |          |
 |  2 | git                  | 1:2.34.1-1ubuntu1.11 | 1:2.34.1-1ubuntu1.11 |          |
 |  3 | unzip                | 6.0-26ubuntu3.2      | 6.0-26ubuntu3.2      |          |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10/language_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-python-3.10/language_deps/apt_get_packages_diff.md
@@ -3,6 +3,6 @@
 |    | Package           | Version in 8.3.0        | Version in 9.0.0   | Status   |
 |---:|:------------------|:------------------------|:-------------------|:---------|
 |  0 | ca-certificates   | 20230311ubuntu0.22.04.1 | 20240203~22.04.1   | UPDATED  |
-|  1 | curl              | 7.81.0-1ubuntu1.17      | 7.81.0-1ubuntu1.18 | UPDATED  |
-|  2 | python3.10-dev    | 3.10.12-1~22.04.5       | 3.10.12-1~22.04.6  | UPDATED  |
+|  1 | curl              | 7.81.0-1ubuntu1.17      | 7.81.0-1ubuntu1.19 | UPDATED  |
+|  2 | python3.10-dev    | 3.10.12-1~22.04.5       | 3.10.12-1~22.04.7  | UPDATED  |
 |  3 | python3-distutils | 3.10.8-1~22.04          | 3.10.8-1~22.04     |          |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-r-4/build_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-r-4/build_deps/apt_get_packages_diff.md
@@ -2,7 +2,7 @@
 
 |    | Package           | Version in 8.3.0             | Version in 9.0.0             | Status   |
 |---:|:------------------|:-----------------------------|:-----------------------------|:---------|
-|  0 | curl              | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.18           | UPDATED  |
+|  0 | curl              | 7.81.0-1ubuntu1.17           | 7.81.0-1ubuntu1.19           | UPDATED  |
 |  1 | openjdk-11-jdk    | 11.0.24+8-1ubuntu3~22.04     | 11.0.25+9-1ubuntu1~22.04     | UPDATED  |
 |  2 | build-essential   | 12.9ubuntu3                  | 12.9ubuntu3                  |          |
 |  3 | chrpath           | 0.16-2                       | 0.16-2                       |          |

--- a/doc/changes/package_diffs/9.0.0/template-Exasol-all-r-4/language_deps/apt_get_packages_diff.md
+++ b/doc/changes/package_diffs/9.0.0/template-Exasol-all-r-4/language_deps/apt_get_packages_diff.md
@@ -3,4 +3,4 @@
 |    | Package         | Version in 8.3.0        | Version in 9.0.0   | Status   |
 |---:|:----------------|:------------------------|:-------------------|:---------|
 |  0 | ca-certificates | 20230311ubuntu0.22.04.1 | 20240203~22.04.1   | UPDATED  |
-|  1 | curl            | 7.81.0-1ubuntu1.17      | 7.81.0-1ubuntu1.18 | UPDATED  |
+|  1 | curl            | 7.81.0-1ubuntu1.17      | 7.81.0-1ubuntu1.19 | UPDATED  |

--- a/flavors/standard-EXASOL-all/flavor_base/build_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-all/flavor_base/build_deps/packages/apt_get_packages
@@ -1,7 +1,7 @@
 coreutils|8.32-4.1ubuntu1.2
 locales|2.35-0ubuntu3.8
 tar|1.34+dfsg-1ubuntu0.1.22.04.2
-curl|7.81.0-1ubuntu1.18
+curl|7.81.0-1ubuntu1.19
 openjdk-11-jdk|11.0.25+9-1ubuntu1~22.04
 build-essential|12.9ubuntu3
 libpcre3-dev|2:8.39-13ubuntu0.22.04.1

--- a/flavors/standard-EXASOL-all/flavor_base/flavor_base_deps_apt/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-all/flavor_base/flavor_base_deps_apt/packages/apt_get_packages
@@ -1,6 +1,6 @@
 unzip|6.0-26ubuntu3.2
 git|1:2.34.1-1ubuntu1.11
-libcurl4-openssl-dev|7.81.0-1ubuntu1.18
+libcurl4-openssl-dev|7.81.0-1ubuntu1.19
 build-essential|12.9ubuntu3
 wget|1.21.2-2ubuntu1.1
 maven|3.6.3-5

--- a/flavors/standard-EXASOL-all/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/standard-EXASOL-all/flavor_base/language_deps/packages/apt_get_packages
@@ -1,6 +1,6 @@
 ca-certificates|20240203~22.04.1
-python3.10-dev|3.10.12-1~22.04.6
+python3.10-dev|3.10.12-1~22.04.7
 python3-distutils|3.10.8-1~22.04
-curl|7.81.0-1ubuntu1.18
+curl|7.81.0-1ubuntu1.19
 openjdk-11-jdk-headless|11.0.25+9-1ubuntu1~22.04
 chrpath|0.16-2

--- a/flavors/template-Exasol-all-r-4/flavor_base/build_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-r-4/flavor_base/build_deps/packages/apt_get_packages
@@ -1,7 +1,7 @@
 coreutils|8.32-4.1ubuntu1.2
 locales|2.35-0ubuntu3.8
 tar|1.34+dfsg-1ubuntu0.1.22.04.2
-curl|7.81.0-1ubuntu1.18
+curl|7.81.0-1ubuntu1.19
 openjdk-11-jdk|11.0.25+9-1ubuntu1~22.04
 build-essential|12.9ubuntu3
 libpcre3-dev|2:8.39-13ubuntu0.22.04.1

--- a/flavors/template-Exasol-all-r-4/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-r-4/flavor_base/language_deps/packages/apt_get_packages
@@ -1,2 +1,2 @@
 ca-certificates|20240203~22.04.1
-curl|7.81.0-1ubuntu1.18
+curl|7.81.0-1ubuntu1.19


### PR DESCRIPTION
closes #1019 


### All Submissions:

* [x] Check if your pull request goes to the correct bash branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
