### PR TITLE
#1098: Allow setting script-options-parser version via cli argument

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 6cab2dbfdf9ae1e4f0fbbf7a7a2bc5c31df8dcf5 0	script-languages
+160000 df2f9bd4ea2db9c8fba5d3946f5d556c0a19bbf5 0	script-languages

--- a/doc/changes/changes_9.4.0.md
+++ b/doc/changes/changes_9.4.0.md
@@ -15,6 +15,7 @@ This release uses version 3.0.0 of the container tool.
 ## Features
 
  - Replaced flavor `template-Exasol-all-java-17` with `standard-EXASOL-all-java-17`
+ - #1098: Allow setting script-options-parser version via cli argument
 
 ## Security Issues
 

--- a/exaudfclient/exaudfclient.cc
+++ b/exaudfclient/exaudfclient.cc
@@ -37,6 +37,8 @@
 #endif
 #include <inttypes.h>
 
+
+
 #ifdef ENABLE_JAVA_VM
 #include "base/javacontainer/javacontainer_builder.h"
 #endif //ENABLE_JAVA_VM
@@ -65,6 +67,10 @@ int exaudfclient_main(std::function<SWIGVM*()>vmMaker,int argc,char**argv);
 void set_SWIGVM_params(SWIGVM_params_t* p);
 }
 #endif
+
+void print_usage(const char *prg_name) {
+    std::cerr << "Usage: " << prg_name << " <socket> lang=python|lang=r|lang=java|lang=streaming|lang=benchmark <scriptOptionsParserVersion=1|2>" << endl;
+}
 
 int main(int argc, char **argv) {
 #ifndef UDF_PLUGIN_CLIENT
@@ -125,13 +131,39 @@ int main(int argc, char **argv) {
         return 1;
     }
 #else
-    if (argc != 3) {
-        cerr << "Usage: " << argv[0] << " <socket> lang=python|lang=r|lang=java|lang=streaming|lang=benchmark" << endl;
+    bool cli_use_ctp_parser = false;
+    if (argc < 3 || argc > 4) {
+        print_usage(argv[0]);
         return 1;
     }
+    if (4 == argc) {
+        if(strcmp(argv[3], "scriptOptionsParserVersion=2") == 0) {
+            cli_use_ctp_parser = true;
+        } else if (strcmp(argv[3], "scriptOptionsParserVersion=1") != 0) {
+             print_usage(argv[0]);
+             return 1;
+        }
+    }
     const char* script_options_parser_env_val = ::getenv("SCRIPT_OPTIONS_PARSER_VERSION");
-    const bool useCtpgScriptOptionsParser = script_options_parser_env_val != nullptr &&
-                                            ::strcmp(script_options_parser_env_val, "2") == 0;
+    bool use_ctpg_script_options_parser = false;
+    /*
+     * The given script-options-parser version set by the environment variable "SCRIPT_OPTIONS_PARSER_VERSION"
+     * must have priority over the CLI argument "scriptOptionsParserVersion=x".
+     * This allows clients to override the parser version in a specific UDF, if needed,
+     * via "%env SCRIPT_OPTIONS_PARSER_VERSION=x".
+     */
+    if (script_options_parser_env_val != nullptr) {
+        if (::strcmp(script_options_parser_env_val, "1") == 0) {
+            use_ctpg_script_options_parser = false;
+        } else if (::strcmp(script_options_parser_env_val, "2") == 0) {
+            use_ctpg_script_options_parser = true;
+        } else {
+            print_usage(argv[0]);
+            return 1;
+        }
+    } else {
+        use_ctpg_script_options_parser = cli_use_ctp_parser;
+    }
 
 #endif
 
@@ -171,7 +203,7 @@ int main(int argc, char **argv) {
     } else if (strcmp(argv[2], "lang=java")==0)
     {
 #ifdef ENABLE_JAVA_VM
-        if (useCtpgScriptOptionsParser) {
+        if (use_ctpg_script_options_parser) {
             vmMaker = [&](){return SWIGVMContainers::JavaContainerBuilder().useCtpgParser().build();};
         } else {
             vmMaker = [&](){return SWIGVMContainers::JavaContainerBuilder().build();};


### PR DESCRIPTION
fixes #1098 

### All Submissions:

* [ ] Check if your pull request goes to the correct bash branch (develop or master)?
* [ ] Is the title of the Pull Request correct?
* [ ] Is the title of the corresponding issue correct?
* [ ] Have you updated the changelog?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [ ] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [ ] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
