### PR TITLE
#1146: Reverted the trivy-ignore for CVE-2025-47273

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 70816c4cc35b43f015ad56e6ab291a7db12ac717 0	script-languages
+160000 49f9a36965ad52e3e20cbde27b1a1dda3dc3120d 0	script-languages

--- a/doc/changes/changes_9.7.0.md
+++ b/doc/changes/changes_9.7.0.md
@@ -20,6 +20,7 @@ This release uses version 3.4.1 of the container tool.
 ## Security Issues
 
  - #1193: Update Dependencies on top of 9.6.0
+ - #1146: Reverting a trivy-ignore CVE-2025-47273
 
 ## Refactorings
 


### PR DESCRIPTION
closes #1146 

### All Submissions:

* [x] Check if your pull request goes to the correct base branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [x] Remember to merge with "Merge"
2. [x] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [x] If you plan a release, have you checked the Exasol packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
