### PR TITLE
#1094: Removed ssl dependency

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 6aad7bdcad46af6935cd2d7a47d8475ccc19f07b 0	script-languages
+160000 51a6ebbd038ea665060ae601348cdc7b821fb49e 0	script-languages

--- a/doc/changes/changes_10.1.0.md
+++ b/doc/changes/changes_10.1.0.md
@@ -22,6 +22,8 @@ n/a
 
 ## Refactorings
 
+ - #1094: Removed ssl dependency 
+
 n/a
 
 ## Dependencies


### PR DESCRIPTION
closes #1094 
### All Submissions:

* [x] Check if your pull request goes to the correct base branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
