### PR TITLE
Added workaround for #1435: Pining packaging Python module to version 25.0

### DIFF
--- a/doc/changes/changes_11.2.0.md
+++ b/doc/changes/changes_11.2.0.md
@@ -34,7 +34,7 @@ n/a
 
 ## Bugs
 
-n/a
+ - Added workaround for #1435: Pining packaging Python module to version 25.0
 
 ## Doc
 
@@ -43,4 +43,3 @@ n/a
 ## Internal
 
  - Relocked dependencies
- - Added workaround for #1435: Pining packaging Python module to version 25.0

--- a/doc/changes/changes_11.2.0.md
+++ b/doc/changes/changes_11.2.0.md
@@ -43,3 +43,4 @@ n/a
 ## Internal
 
  - Relocked dependencies
+ - Added workaround for #1435: Pining packaging Python module to version 25.0

--- a/flavors/standard-EXASOL-all/packages.yml
+++ b/flavors/standard-EXASOL-all/packages.yml
@@ -86,6 +86,11 @@ build_steps:
       - name: pyarrow
         version: ==16.0.0
         extras: []
+      - comment: workaround for failing integration tests, see https://github.com/exasol/script-languages-release/issues/1435
+        name: packaging
+        version: ==25.0
+        extras: []
+
       install_build_tools_ephemerally: false
   validation_cfg:
     version_mandatory: true


### PR DESCRIPTION
workaround for #1435

### All Submissions:

* [x] Check if your pull request goes to the correct base branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [ ] Have you generated the packages diffs?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [ ] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol/partner packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
   3. [PyExasol](https://pypi.org/project/pyexasol/)
   4. [sqlglot](https://pypi.org/project/sqlglot/)
