### PR TITLE
Fix 'standard-EXASOL-all' flavor: trivy 0.69.3 not found (fixes #1438)

### DIFF
--- a/doc/changes/changes_11.2.0.md
+++ b/doc/changes/changes_11.2.0.md
@@ -35,6 +35,7 @@ n/a
 ## Bugs
 
  - Added workaround for #1435: Pining packaging Python module to version 25.0
+ - #1438: Fixed 'standard-EXASOL-all' flavor: trivy 0.69.3 not found
 
 ## Doc
 

--- a/flavors/standard-EXASOL-all/flavor_base/packages.yml
+++ b/flavors/standard-EXASOL-all/flavor_base/packages.yml
@@ -50,4 +50,22 @@ build_steps:
         version: 5.16-0ubuntu*
   validation_cfg:
     version_mandatory: true
+- name: security_scan
+  phases:
+  - name: install_deps
+    apt:
+      packages:
+        - name: gnupg
+  - name: install_apt_packages
+    apt:
+      repos:
+        trivy:
+          key_url: https://aquasecurity.github.io/trivy-repo/deb/public.key
+          entry: deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb
+            generic main
+          out_file: trivy.list
+      packages:
+      - name: trivy
+  validation_cfg:
+    version_mandatory: false
 version: 1.0.0

--- a/flavors/standard-EXASOL-all/flavor_base/security_scan/Dockerfile
+++ b/flavors/standard-EXASOL-all/flavor_base/security_scan/Dockerfile
@@ -1,7 +1,9 @@
 FROM {{release}}
 ENV DEBIAN_FRONTEND=noninteractive
 
-#No invocation of exaslpm needed because trivy was already installed in the release image
+RUN mkdir -p /build_info/packages
+COPY security_scan_packages.yml /build_info/packages/security_scan_packages.yml
+RUN exaslpm install --package-file /build_info/packages/security_scan_packages.yml --build-step security_scan
 
 ENV SECURITY_SCANNERS="trivy"
 COPY /security_scan/.trivyignore /.trivyignore

--- a/flavors/standard-EXASOL-all/packages.yml
+++ b/flavors/standard-EXASOL-all/packages.yml
@@ -98,12 +98,6 @@ build_steps:
   phases:
   - name: install_apt_packages
     apt:
-      repos:
-        trivy:
-          key_url: https://aquasecurity.github.io/trivy-repo/deb/public.key
-          entry: deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb
-            generic main
-          out_file: trivy.list
       packages:
       - name: unzip
         version: 6.0-26ubuntu*
@@ -148,8 +142,6 @@ build_steps:
         version: 2:4.15.13+dfsg-0ubuntu*
       - name: cmake
         version: 3.22.1-1ubuntu*
-      - name: trivy
-        version: 0.69.3
       - name: libleveldb-dev
         version: 1.23-3build1
   validation_cfg:


### PR DESCRIPTION
fixes #1438

### All Submissions:

* [x] Check if your pull request goes to the correct base branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [ ] Have you generated the packages diffs?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [ ] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol/partner packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
   3. [PyExasol](https://pypi.org/project/pyexasol/)
   4. [sqlglot](https://pypi.org/project/sqlglot/)
