### PR TITLE
#1442: Added new preprocessor flag USE_STATIC_SWIG

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 ceac095743e8204c9ce1b41e5bf4249e26854110 0	script-languages
+160000 cd4407a63b65c4c16e6fe8ee66dd49deccc5c8f7 0	script-languages

--- a/doc/changes/changes_11.2.0.md
+++ b/doc/changes/changes_11.2.0.md
@@ -28,6 +28,7 @@ n/a
  - #1425: Updated tzdata version (2025b to 2026a)
  - #1432: Fixed UDF Plugin
  - #1415: Removed legacy package files
+ - #1442: Added new preprocessor flag USE_STATIC_SWIG
 
 ## Dependencies
 

--- a/exaudfclient/exaudfclient.cc
+++ b/exaudfclient/exaudfclient.cc
@@ -170,6 +170,18 @@ int main(int argc, char **argv) {
 
 #endif
 
+#ifndef UDF_PLUGIN_CLIENT
+    if (! ((strcmp(argv[2], "lang=python") == 0)
+           || (strcmp(argv[2], "lang=java") == 0)
+           || (strcmp(argv[2], "lang=r") == 0)
+           || (strcmp(argv[2], "lang=streaming") == 0)
+           || (strcmp(argv[2], "lang=benchmark") == 0)) )
+    {
+        PRINT_ERROR_MESSAGE(std::cerr,"F-UDF-CL-LIB-1121","Remote VM type '" << argv[2] << "' not supported.");
+        return 2;
+    }
+#endif
+
     if (::setenv("HOME", "/tmp", 1) == -1)
     {
         throw SWIGVM::exception("Failed to set HOME directory");


### PR DESCRIPTION
fixes #1442 

### All Submissions:

* [x] Check if your pull request goes to the correct base branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [x] Have you generated the packages diffs?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol/partner packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
   3. [PyExasol](https://pypi.org/project/pyexasol/)
   4. [sqlglot](https://pypi.org/project/sqlglot/)
