### PR TITLE
Fixed 'standard-EXASOL-all' flavor: Prevent upgrade to R 4.6.0 (fixes  #1449)

### DIFF
--- a/doc/changes/changes_11.2.0.md
+++ b/doc/changes/changes_11.2.0.md
@@ -40,6 +40,7 @@ n/a
 
  - Added workaround for #1435: Pining packaging Python module to version 25.0
  - #1438: Fixed 'standard-EXASOL-all' flavor: trivy 0.69.3 not found
+ - #1449: Fixed 'standard-EXASOL-all' flavor: Prevent upgrade to R 4.6.0
 
 ## Doc
 

--- a/flavors/standard-EXASOL-all/packages.yml
+++ b/flavors/standard-EXASOL-all/packages.yml
@@ -378,6 +378,8 @@ build_steps:
       - name: portalocker
         version: ==3.1.1
         extras: []
+      # disabled: r-base-dev already installs all needed build tools,
+      # otherwise R is upgraded to version 4.6.0, which is incompatible with the UDF client
       install_build_tools_ephemerally: false
   validation_cfg:
     version_mandatory: false

--- a/flavors/standard-EXASOL-all/packages.yml
+++ b/flavors/standard-EXASOL-all/packages.yml
@@ -378,7 +378,7 @@ build_steps:
       - name: portalocker
         version: ==3.1.1
         extras: []
-      install_build_tools_ephemerally: true
+      install_build_tools_ephemerally: false
   validation_cfg:
     version_mandatory: false
 - name: flavor_base_deps_r


### PR DESCRIPTION
fixes  #1449

### All Submissions:

* [x] Check if your pull request goes to the correct base branch (develop or master)?
* [x] Is the title of the Pull Request correct?
* [x] Is the title of the corresponding issue correct?
* [x] Have you updated the changelog?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line --> 
* [x] Are you mentioning the issue which this PullRequest fixes ("Fixes...")
* [ ] Have you generated the packages diffs?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### When integrating to Develop branch:

1. [x] Remember to merge with "Squash and Merge"

### When integrating to Main branch:

1. [ ] Remember to merge with "Merge"
2. [ ] Have you thought about version number? If there is a breaking change in the toolchain, need to update major version.
3. [ ] If you plan a release, have you checked the Exasol/partner packages for updates?
   1. Websocket API (https://github.com/EXASOL/websocket-api)
   2. [Exasol-BucketFS](https://pypi.org/project/exasol-bucketfs/)
   3. [PyExasol](https://pypi.org/project/pyexasol/)
   4. [sqlglot](https://pypi.org/project/sqlglot/)
